### PR TITLE
Potential fix for code scanning alert no. 37: Missing rate limiting

### DIFF
--- a/Local/Ai_Placement_Helper/backend/package.json
+++ b/Local/Ai_Placement_Helper/backend/package.json
@@ -10,7 +10,8 @@
     "express": "^4.21.2",
     "jsonrepair": "^3.12.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.13.0"
+    "mongoose": "^8.13.0",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/Local/Ai_Placement_Helper/backend/routes/userRoutes.js
+++ b/Local/Ai_Placement_Helper/backend/routes/userRoutes.js
@@ -3,6 +3,16 @@ import User from "../database_models/User.js"; // Ensure correct path
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import mongoose from "mongoose";
+import rateLimit from "express-rate-limit";
+
+// Rate limiter for login route: max 5 requests per minute per IP
+const loginLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5,
+  message: { message: "Too many login attempts from this IP, please try again after a minute." },
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
 
 const router = express.Router();
 
@@ -61,7 +71,7 @@ router.post("/register", async (req, res) => {
 });
 
 // User login
-router.post("/login", async (req, res) => {
+router.post("/login", loginLimiter, async (req, res) => {
   try {
     console.log('Login attempt:', new Date().toISOString());
     let { email, password } = req.body;


### PR DESCRIPTION
Potential fix for [https://github.com/LohithG2503/Ai_Placements_Helper/security/code-scanning/37](https://github.com/LohithG2503/Ai_Placements_Helper/security/code-scanning/37)

To fix the missing rate limiting, we should add a rate-limiting middleware to the `/login` route (and ideally also to `/register`, but the alert is for `/login`). The best way to do this in an Express app is to use the well-known `express-rate-limit` package. We will:

- Import `express-rate-limit` at the top of the file.
- Define a rate limiter instance with reasonable defaults (e.g., 5 login attempts per minute per IP).
- Apply this rate limiter as middleware to the `/login` route.
- This change will only affect the `/login` route and will not interfere with other routes or existing functionality.

All changes will be made within `Local/Ai_Placement_Helper/backend/routes/userRoutes.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
