### PR TITLE
Potential fix for code scanning alert no. 32: Regular expression injection

### DIFF
--- a/Cloud/Ai_Placement_Helper/backend/package.json
+++ b/Cloud/Ai_Placement_Helper/backend/package.json
@@ -11,7 +11,8 @@
     "express": "^4.21.2",
     "jsonrepair": "^3.12.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.13.0"
+    "mongoose": "^8.13.0",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/Cloud/Ai_Placement_Helper/backend/src/controllers/companyController.js
+++ b/Cloud/Ai_Placement_Helper/backend/src/controllers/companyController.js
@@ -2,6 +2,7 @@ import CompanyService from '../services/companyService.js';
 import axios from 'axios';
 import dotenv from 'dotenv';
 import path from 'path';
+import _ from 'lodash';
 
 // Load environment variables from the backend directory
 dotenv.config({ path: path.resolve(process.cwd(), '../../backend/.env') });
@@ -314,7 +315,8 @@ async function fetchFromSerpApi(companyName) {
       
       // If industry is unknown, try to extract from snippets
       if (companyData.industry === 'Unknown' || companyData.industry === getIndustryFallback(companyName)) {
-        const industryRegex = new RegExp(`${companyName}.*?(?:is an?|operates in|specializes in)\\s+([\\w\\s,&-]+?)(?:company|business|firm|that|which|\\.|$)`, 'i');
+        const safeCompanyName = _.escapeRegExp(companyName);
+        const industryRegex = new RegExp(`${safeCompanyName}.*?(?:is an?|operates in|specializes in)\\s+([\\w\\s,&-]+?)(?:company|business|firm|that|which|\\.|$)`, 'i');
         
         for (const result of industryResults) {
           if (result.snippet) {


### PR DESCRIPTION
Potential fix for [https://github.com/LohithG2503/Ai_Placements_Helper/security/code-scanning/32](https://github.com/LohithG2503/Ai_Placements_Helper/security/code-scanning/32)

To fix this issue, we need to sanitize the `companyName` variable before embedding it in the regular expression. The best way to do this is to escape all regex metacharacters in `companyName` using a well-tested utility function. Lodash's `_.escapeRegExp` is a standard choice for this purpose. We should import lodash, use `_.escapeRegExp(companyName)` when constructing the regex, and ensure that only the sanitized version is used in the regex pattern. The changes are limited to the region where the regex is constructed (line 317 in `fetchFromSerpApi`), and we need to add the lodash import at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
